### PR TITLE
Add article on Swift 6.3 release for Android

### DIFF
--- a/Reports/2026/#368-2026.04.13.md
+++ b/Reports/2026/#368-2026.04.13.md
@@ -47,6 +47,10 @@
 
 [@DylanYang](https://github.com/Dylan19Yang)：本文作者主要讲解了 SwiftUI 中被 @Observable 修饰的类初始化方法多次执行的问题，核心原因是使用 @State 存储 ViewModel 时，会随 View 频繁重建重复执行初始化逻辑，搭配 NavigationStack 导航场景会进一步加剧该问题。作者同时给出了.task 延迟赋值、将 ViewModel 托管至上层视图等解决方案，并提醒开发者不要在 init 中编写耗时操作与副作用逻辑。
 
+### 🐕 [Swift 6.3 正式发布支持 Android，它能在跨平台发挥什么优势？](https://mp.weixin.qq.com/s/biU1GkLHAF9OH5FHRSbiVg)
+
+[@JonyFang](https://github.com/JonyFang)：Swift 6.3 带来了首个正式的 Swift SDK for Android，这篇文章从工具链、互操作和实际落地三个角度做了比较完整的梳理。编译上，Swift 借助 LLVM 直接交叉编译出 Android 的 ELF 产物（.so），一行 swift build --swift-sdk x86_64-unknown-linux-android28 就能搞定，不依赖额外 IDE。互操作方面主要靠 swift-java 和 swift-java-jni-core 两个库：前者通过 @JavaClass、@JavaMethod 等宏让 Swift 调 Java，也能用 jextract --mode=jni 反过来生成 Thunk 让 Java 调 Swift；后者则把 JNI 底层操作（JVM 生命周期、类型桥接等）封装成了 Swift 风格的 API。落地架构上，官方推荐"Swift 写业务逻辑 + Kotlin/Jetpack Compose 写 UI"，weather-app 示例就是这个思路。不过文章也提到了现阶段的局限：没有 SwiftUI for Android 这样的 UI 层，访问 Android 系统 API 得走 Swift → JNI → Java/Kotlin → Android API 这条链路，和 KMP 能直接共享 UI（CMP）比还有差距。总的来说，Swift for Android 目前更适合把现有的 Swift 业务逻辑/算法库复用到 Android 端，后续在 UI 层和工具链上的演进值得持续关注。
+
 ## 内推
 
 重新开始更新「iOS 靠谱内推专题」，整理了最近明确在招人的岗位，供大家参考


### PR DESCRIPTION
Added a new section discussing the official release of Swift 6.3 for Android and its advantages for cross-platform development.

close https://github.com/SwiftOldDriver/iOS-Weekly/issues/5321