### PR TITLE
Add iOS 27 SDK requirements for app compatibility

### DIFF
--- a/Reports/2026/#374-2026.07.06.md
+++ b/Reports/2026/#374-2026.07.06.md
@@ -72,6 +72,16 @@ SwiftUI 只是底层技术栈（Core Animation、Core Graphics、Core Text、Cor
 
 虽然现在需要我们直接调试和优化底层 Prompt 的场景越来越少，但研究这些优秀 Prompt 的设计方式，仍然可以帮助我们理解产品背后的处理策略。理解这些策略，不仅能让我们更有效地使用对应产品，也能为设计自己的自动化流程和 Agent 提供参考。
 
+### 🐎 [iOS 27 SDK: 3 Major Requirements That Might Break Your App](https://blog.makwanbk.com/ios-27-sdk-3-major-requirements-that-migh-break-your-app)
+
+[@JonyFang](https://github.com/JonyFang)：这篇文章整理了 iOS 27 SDK（Xcode 27）开始强制执行、且可能影响现有 App 的三项要求：
+
+- **UIScene 生命周期**：使用新 SDK 构建的 App 需迁移到 Scene-based lifecycle，补齐 `UIApplicationSceneManifest` 和 `SceneDelegate`，否则可能启动即崩。
+- **Launch Screen 配置**：App Store Connect 会检查 `Info.plist` 中是否声明启动屏配置，老项目或迁移项目需要提前确认，避免触发 ITMS-90870 被拒。
+- **Liquid Glass 适配**：`UIDesignRequiresCompatibility` 兼容开关在 iOS 27 中不再生效，导航栏、Tab Bar、滚动视图和自定义 UIKit 样式都需要重新验证展示效果。
+
+这篇文章适合在维护 UIKit 项目、或准备升级 Xcode 27 构建链的开发快速自查。三项改动本身不复杂，但都属于会影响启动、提审或 UI 表现的 SDK 级要求，建议尽早在 iOS 27 模拟器上完成验证。
+
 ## 工具
 
 > 开发过程中常用的工具，及一些新工具的介绍


### PR DESCRIPTION
Added a section about iOS 27 SDK requirements that may affect existing apps, including UIScene lifecycle, Launch Screen configuration, and Liquid Glass compatibility.

close https://github.com/SwiftOldDriver/iOS-Weekly/issues/5384