### PR TITLE
Add 'sim-use' section for mobile development insights

### DIFF
--- a/Reports/2026/#375-2026.07.20.md
+++ b/Reports/2026/#375-2026.07.20.md
@@ -29,7 +29,9 @@
 
 [@Cooper Chen](https://github.com/cjlcooper)：这篇文章聚焦 Xcode 27 的 Agentic Development 新能力，手把手演示如何将 Cursor 作为 ACP 兼容代理接入 Xcode。内容从安装 Cursor agent CLI、配置可执行文件与参数，到在新会话中选择代理，流程清晰实用。适合希望保留 Xcode 原生体验，同时借助 Cursor 提升开发效率的 iOS/macOS 开发者阅读。
 
+### 🐢 [sim-use - 给 agent 装上眼睛和手，让 mobile 开发跟上 AI 时代](https://onevcat.com/2026/07/sim-use/)
 
+[@JonyFang](https://github.com/JonyFang)：随着 Agent 写代码越来越快，移动端开发的瓶颈也逐渐转向了如何验证结果。本文介绍 onevcat 开源的跨平台工具 `sim-use`，它能让 Agent 看懂并操作 iOS、Android 界面，自主完成交互和验证。文章还分享了 Outline DSL、UI 元素探测、常驻 Daemon 等关键设计，是一篇很有参考价值的 Mobile Agent 工程实践。
 
 
 ## 工具


### PR DESCRIPTION
Added a new section about 'sim-use' for mobile development and its capabilities.

close https://github.com/SwiftOldDriver/iOS-Weekly/issues/5388