### PR TITLE
Add Swift Programming Language versioned documentation

### DIFF
--- a/Reports/2026/#377-2026.08.17.md
+++ b/Reports/2026/#377-2026.08.17.md
@@ -27,7 +27,11 @@
 
 ## 工具
 
-> 开发过程中常用的工具，及一些新工具的介绍
+### 🐎 [The Swift Programming Language：可切换历史版本的官方 Swift 书](https://docclab.github.io/swift-book/main/documentation/the-swift-programming-language/)
+
+[@JonyFang](https://github.com/JonyFang)：官方 TSPL 一直是查语法、补语言特性和带新人入门的标准参考，但 [docs.swift.org](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/) 通常只提供当前版本。这个站点用 VersionedDocC 按 Swift 发行标签重新构建了同一本书，页头可以直接在 `main`（6.4 beta）、6.3、6.2.x、6.1、6、5.10 一直到 5.7 共 12 个版本之间切换，每个版本都有稳定 URL。
+
+更有用的是相邻版本的 Changes 页：6.3 到 main 能看到 Concurrency、Protocols、Opaque Types 等 9 处修订，5.8 到 5.9 则能直接定位到新增的 Macros 章。维护旧工程、或想对照语言书在版本间怎么改的时候，比只看最新版方便很多。正文源码仍指向 [swiftlang/swift-book](https://github.com/swiftlang/swift-book)。
 
 ## 代码
 


### PR DESCRIPTION
Updated the report to include a new section on the Swift Programming Language with versioned documentation and changes across versions.

Close https://github.com/SwiftOldDriver/iOS-Weekly/issues/5408